### PR TITLE
[Infinite scroll] Prevent reloading of the beginning of the list after the end of the list

### DIFF
--- a/src/list/load-action/builder.js
+++ b/src/list/load-action/builder.js
@@ -28,11 +28,10 @@ function pagination(opts) {
         if (dataList.length < totalCount) {
             return { top: nbElement, skip: dataList.length };
         }
-    } else {
-        return {
-            top: nbElement,
-            skip: 0
-        }
+    }
+    return {
+        top: nbElement,
+        skip: 0
     }
 }
 

--- a/src/list/load-action/builder.js
+++ b/src/list/load-action/builder.js
@@ -28,10 +28,11 @@ function pagination(opts) {
         if (dataList.length < totalCount) {
             return { top: nbElement, skip: dataList.length };
         }
-    }
-    return {
-        top: nbElement,
-        skip: 0
+    } else {
+        return {
+            top: nbElement,
+            skip: 0
+        }
     }
 }
 

--- a/src/list/load-action/index.js
+++ b/src/list/load-action/index.js
@@ -4,6 +4,7 @@ import _builder from './builder';
 import _parser from './parser';
 import dispatcher from '../../dispatcher';
 import { manageResponseErrors } from '../../network/error-parsing';
+import { isArray } from 'lodash';
 
 
 /**
@@ -46,6 +47,11 @@ export default function loadActionFn(config) {
             groupingKey, sortBy, sortAsc,
             dataList, totalCount
         } = config.getListOptions();
+
+        // Exit if the number of elements is equal or over the total number of available items
+        if (isScroll && isArray(dataList) && dataList.length >= totalCount) {
+            return;
+        }
 
         //Number of element to search on each search.
         const nbElement = config.nbElement;


### PR DESCRIPTION
## [Fix problem with infinite scroll] Prevent reloading of the beginning of the list after the end of the list

### Description

When scrolling down, the list loads the end of the list and reloads the beginning of the list.

### Patch

Prevent sending of a new call which reloads the beginning of the list when the list loads the end of the list.
> Fixes #442
